### PR TITLE
chore: bump minor (`0.7.0`) -> (`0.8.0`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@zero-tech/zapp-daos",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@zero-tech/zapp-daos",
-			"version": "0.7.0",
+			"version": "0.8.0",
 			"license": "ISC",
 			"dependencies": {
 				"@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-daos",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"main": "dist/index.js",
 	"repository": "git@github.com:zer0-os/zApp-DAOs.git",
 	"scripts": {


### PR DESCRIPTION
- chore: bump minor (`0.7.0`) -> (`0.8.0`)
- run `npm i` so package-lock.json has correct version number