### PR TITLE
fix: proposal attribute and voting loading display

### DIFF
--- a/src/pages/Proposal/Proposal.tsx
+++ b/src/pages/Proposal/Proposal.tsx
@@ -21,11 +21,8 @@ export const Proposal: FC = () => {
 	const { proposalId } = useParams<{ proposalId: ProposalId }>();
 	const { zna } = useCurrentDao();
 
-	const { isLoadingVotes, proposal, votes, refetch, dao } = useProposalPageData(
-		{ proposalId, zna }
-	);
-
-	const isLoadingProposal = true;
+	const { isLoadingProposal, isLoadingVotes, proposal, votes, refetch, dao } =
+		useProposalPageData({ proposalId, zna });
 
 	const shouldShowVoteBar =
 		proposal &&

--- a/src/pages/Proposal/components/Attributes/Attributes.tsx
+++ b/src/pages/Proposal/components/Attributes/Attributes.tsx
@@ -20,7 +20,7 @@ type AttributesProps = {
 
 export const Attributes = ({ proposalId, zna }: AttributesProps) => {
 	const { chainId } = useWeb3();
-	const { data: proposal } = useDaoProposal({
+	const { data: proposal, isLoading: isLoadingProposal } = useDaoProposal({
 		zna,
 		proposalId
 	});
@@ -31,8 +31,6 @@ export const Attributes = ({ proposalId, zna }: AttributesProps) => {
 	const timeRemaining = proposal
 		? moment(proposal.end).diff(moment())
 		: undefined;
-
-	const isLoadingProposal = true;
 
 	return (
 		<AttributeWrapper>


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Jira Task](https://wilderworld.atlassian.net/jira/software/c/projects/ZAP/boards/34?modal=detail&selectedIssue=ZAP-173)

---

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] Jira task has been moved to the Code Review column
- [x] Link to Jira task at the top of this PR
- [x] Jira task has a link to this PR
- [x] PR name follows [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

## 2. PR type
- bugfix

## 3. What is the old behaviour?
Loading issue for proposal attributes and voting data elements

## 4. What is the new behaviour?
Loading issue resolved. Correct data that is fetched is displayed in the correct elements on the UI.

<img width="1440" alt="Screenshot 2023-05-03 at 12 00 14" src="https://user-images.githubusercontent.com/39112648/235820195-9f6ebc07-7856-4ad3-ae00-b9cd71ba9219.png">


Note: There is an issue with `listVotes` which was previously recorded in CPT backlog.