### PR TITLE
chore: bump version (`0.9.0`) -> (`0.9.1`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@zero-tech/zapp-daos",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@zero-tech/zapp-daos",
-			"version": "0.9.0",
+			"version": "0.9.1",
 			"license": "ISC",
 			"dependencies": {
 				"@babel/plugin-proposal-class-properties": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-daos",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"main": "dist/index.js",
 	"repository": "git@github.com:zer0-os/zApp-DAOs.git",
 	"scripts": {


### PR DESCRIPTION
- chore: bump version (`0.9.0`) -> (`0.9.1`)
- run `npm i` to update `package-lock.json` version number for publishing